### PR TITLE
Add d3 line interpolation customizability

### DIFF
--- a/charts/chart.area.js
+++ b/charts/chart.area.js
@@ -133,6 +133,10 @@ area.prototype.getSpec = function() {
 
 
 function getAreaMark(config, metadata){
+    interpolation = "linear";
+    if (config.interpolation){
+      interpolation = config.interpolation;
+    }
 
     var mark;
     if (config.color != -1 && config.mode == "stack") {
@@ -155,7 +159,8 @@ function getAreaMark(config, metadata){
                             "y2": {"scale": "y", "field": "layout_end"},
                             "fill": {"scale": "color", "field": metadata.names[config.color]},
                             "strokeWidth": {"value": 2},
-                            "fillOpacity": {"value": config.fillOpacity}
+                            "fillOpacity": {"value": config.fillOpacity},
+                            "interpolate": {"value": interpolation}
                         },
                         "hover": {
                             "strokeOpacity": {"value": 0.5}
@@ -181,7 +186,8 @@ function getAreaMark(config, metadata){
                             "y2": {"scale": "y", "value": 0},
                             "fill": {"scale": "color", "field": metadata.names[config.color]},
                             "strokeWidth": {"value": 2},
-                            "fillOpacity": {"value": config.fillOpacity}
+                            "fillOpacity": {"value": config.fillOpacity},
+                            "interpolate": {"value": interpolation}
                         },
                         "hover": {
                             "strokeOpacity": {"value": 0.5}
@@ -203,7 +209,8 @@ function getAreaMark(config, metadata){
                     "y2": {"scale": "y", "value": 0},
                     "fill": { "value": config.markColor},
                     "strokeWidth": {"value": 2},
-                    "fillOpacity": {"value": config.fillOpacity}
+                    "fillOpacity": {"value": config.fillOpacity},
+                    "interpolate": {"value": interpolation}
                 },
                 "hover": {
                     "fillOpacity": {"value": 0.5}

--- a/charts/chart.line.js
+++ b/charts/chart.line.js
@@ -128,6 +128,10 @@ line.prototype.getSpec = function() {
 
 
 function getLineMark(config, metadata){
+    interpolation = "linear";
+    if (config.interpolation){
+      interpolation = config.interpolation;
+    }
 
     var mark;
     if (config.color != -1 && config.mode == "stack") {
@@ -149,7 +153,8 @@ function getLineMark(config, metadata){
                             "y": {"scale": "y", "field": "layout_start"},
                             "y2": {"scale": "y", "field": "layout_end"},
                             "stroke": {"scale": "color", "field": metadata.names[config.color]},
-                            "strokeWidth": {"value": 2}
+                            "strokeWidth": {"value": 2},
+                            "interpolate": {"value": interpolation}
                         },
                         "hover": {
                             "strokeOpacity": {"value": 0.5}
@@ -174,7 +179,8 @@ function getLineMark(config, metadata){
                             "y": {"scale": "y", "field": metadata.names[config.y]},
                             "y2": {"scale": "y", "value": 0},
                             "stroke": {"scale": "color", "field": metadata.names[config.color]},
-                            "strokeWidth": {"value": 2}
+                            "strokeWidth": {"value": 2},
+                            "interpolate": {"value": interpolation}
                         },
                         "hover": {
                             "strokeOpacity": {"value": 0.5}
@@ -195,7 +201,8 @@ function getLineMark(config, metadata){
                     "y": {"scale": "y", "field": metadata.names[config.y]},
                     "y2": {"scale": "y", "value": 0},
                     "stroke": { "value": config.markColor},
-                    "strokeWidth": {"value": 2}
+                    "strokeWidth": {"value": 2},
+                    "interpolate": {"value": interpolation}
                 },
                 "hover": {
                     "fillOpacity": {"value": 0.5}


### PR DESCRIPTION
When generating line charts, the smoothness of the rendered chart is not customizable now. In D3 this is managed by `interpolation`, which vega exposes through `marks`. This PR enables to define this interpolation in the view config object as `conf.interpolation = "cardinal"` . The default interpolation will be `linear`.
